### PR TITLE
Several tasks need to be delegated to localhost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 
 install:
   # Install test dependencies.
-  - pip install molecule docker yamllint flake8 ansible-lint
+  - pip install molecule docker yamllint flake8 ansible-lint molecule-docker
 
 before_script:
   # Use actual Ansible Galaxy role name for the project directory.

--- a/tasks/declare.yaml
+++ b/tasks/declare.yaml
@@ -60,6 +60,7 @@
     - atc_method == 'POST'
     - atc_service == "Telemetry"
     - atc_declaration_updated is defined
+  delegate_to: localhost
 
 - name: "GET {{ atc_service }} declaration"
   uri:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -62,6 +62,7 @@
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
   register: atc_response
+  delegate_to: localhost
   until:
     - atc_response is success
     - atc_response.json is defined
@@ -79,6 +80,7 @@
     atc_json_data: "{{ atc_declaration }}"
     atc_version: "{{ atc_response.json }}"
   register: result
+  delegate_to: localhost
   when: check_teem and atc_declaration is defined
 
 - name: Update the atc_declaration
@@ -96,6 +98,7 @@
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
   register: check_bigiq
+  delegate_to: localhost
   ignore_errors: yes
 
 # BIG-IP task check

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -24,6 +24,7 @@
     body_format: json
   when: atc_declaration_url is defined
   register: result
+  delegate_to: localhost
   retries: 10
   delay: 5
 


### PR DESCRIPTION
Unless I'm doing something wrong, or do not understand how this should work, no tasks should be run **on** the BIG-IP via SSH. In order to do a basic AS3 declaration I had to add `delegate_to: localhost` to three tasks.

In my lab, where I'm starting to play with all this, I do not have ssh keys configured between my Ansible controller and my BIG-IP, so these three tasks failed with this error:

`fatal: [bigip102]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Permission denied (publickey,keyboard-interactive,hostbased).", "unreachable": true}`

Editing the role locally and re-running fixed this. To note, `tasks/authentication.yaml` already has `delegate_to: localhost` so the "Get authentication token" and "Test authentication" tasks worked fine before the play aborted.