### PR TITLE
Default server_port (and other provider defaults)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 
 install:
   # Install test dependencies.
-  - pip install molecule docker yamllint flake8 ansible-lint
+  - pip install molecule docker yamllint flake8 ansible-lint molecule-docker
 
 before_script:
   # Use actual Ansible Galaxy role name for the project directory.

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -84,3 +84,7 @@ download_force: true
 
 # Add Control data to AS3 declaration for identifying ansible version
 check_teem: true
+
+# Fill in default values for "provider"
+default_provider:
+  server_port "443"

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -87,4 +87,4 @@ check_teem: true
 
 # Fill in default values for "provider"
 default_provider:
-  server_port "443"
+  server_port: "443"

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -85,6 +85,9 @@ download_force: true
 # Add Control data to AS3 declaration for identifying ansible version
 check_teem: true
 
-# Fill in default values for "provider"
+# Default values for "provider", as specified in Ansible Collection "f5_modules/bigip_device_info"
 default_provider:
+  auth_provider: tmos
   server_port: "443"
+  transport: rest
+  validate_certs: yes

--- a/tasks/atc_task_check_bigip.yaml
+++ b/tasks/atc_task_check_bigip.yaml
@@ -2,12 +2,12 @@
 
 - name: Wait for AS3 Task to complete
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}/mgmt/shared/appsvcs/task/{{ atc_AS3_result.json.id }}"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}/mgmt/shared/appsvcs/task/{{ atc_AS3_result.json.id }}"
     method: GET
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
     return_content: true
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     status_code: 200
   register: atc_AS3_status
   until: atc_AS3_status.json.results | map(attribute='message') | list | first != 'in progress'
@@ -24,12 +24,12 @@
 
 - name: Wait for DO Task to complete
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}{{ atc_url }}/task/{{ atc_DO_result.json.id }}"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}{{ atc_url }}/task/{{ atc_DO_result.json.id }}"
     method: GET
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
     return_content: true
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     status_code: 200
   register: atc_DO_status
   until: atc_DO_status is success

--- a/tasks/atc_task_check_bigiq.yaml
+++ b/tasks/atc_task_check_bigiq.yaml
@@ -2,12 +2,12 @@
 
 - name: Wait for AS3 Task to complete
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}/mgmt/shared/appsvcs/task/{{ atc_AS3_result.json.id }}"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}/mgmt/shared/appsvcs/task/{{ atc_AS3_result.json.id }}"
     method: GET
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
     return_content: true
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     status_code: 200
   register: atc_AS3_status
   until: atc_AS3_status.json.results | map(attribute='message') | list | first != 'in progress'
@@ -30,12 +30,12 @@
 
     - name: Run check
       uri:
-        url: "https://{{ provider.server }}:{{ provider.server_port }}{{ atc_url }}/task/{{ atc_DO_result.json.id }}"
+        url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}{{ atc_url }}/task/{{ atc_DO_result.json.id }}"
         method: GET
         headers:
           X-F5-Auth-Token: "{{ f5_auth_token }}"
         return_content: true
-        validate_certs: "{{ provider.validate_certs }}"
+        validate_certs: "{{ role_provider.validate_certs }}"
         status_code: 200
       register: atc_DO_status
       until: "atc_DO_status is success or atc_DO_status.status == 401"

--- a/tasks/authentication.yaml
+++ b/tasks/authentication.yaml
@@ -9,7 +9,7 @@
     body:
       username: "{{ role_provider.user }}"
       password: "{{ role_provider.password }}"
-      loginProviderName: "{{ role_provider.auth_provider | default('tmos') }}"
+      loginProviderName: "{{ role_provider.auth_provider }}"
     body_format: json
   register: authtoken
   delegate_to: localhost

--- a/tasks/authentication.yaml
+++ b/tasks/authentication.yaml
@@ -2,14 +2,14 @@
 
 - name: Get authentication token
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}/mgmt/shared/authn/login"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}/mgmt/shared/authn/login"
     method: POST
     timeout: "{{ atc_timeout }}"
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     body:
-      username: "{{ provider.user }}"
-      password: "{{ provider.password }}"
-      loginProviderName: "{{ provider.auth_provider | default('tmos') }}"
+      username: "{{ role_provider.user }}"
+      password: "{{ role_provider.password }}"
+      loginProviderName: "{{ role_provider.auth_provider | default('tmos') }}"
     body_format: json
   register: authtoken
   delegate_to: localhost
@@ -21,9 +21,9 @@
 
 - name: Test authentication
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}/mgmt/shared/echo"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}/mgmt/shared/echo"
     timeout: "{{ atc_timeout }}"
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
   register: status

--- a/tasks/declare.yaml
+++ b/tasks/declare.yaml
@@ -54,13 +54,13 @@
     body: "{{ atc_declaration_updated }}"
     status_code: 204, 202, 200
   register: atc_TS_status
-  delegate_to: localhost
   failed_when:
     - atc_TS_status.json.message != 'success'
   when:
     - atc_method == 'POST'
     - atc_service == "Telemetry"
     - atc_declaration_updated is defined
+  delegate_to: localhost
 
 - name: "GET {{ atc_service }} declaration"
   uri:

--- a/tasks/declare.yaml
+++ b/tasks/declare.yaml
@@ -54,6 +54,7 @@
     body: "{{ atc_declaration_updated }}"
     status_code: 204, 202, 200
   register: atc_TS_status
+  delegate_to: localhost
   failed_when:
     - atc_TS_status.json.message != 'success'
   when:

--- a/tasks/declare.yaml
+++ b/tasks/declare.yaml
@@ -1,12 +1,12 @@
 ---
 - name: "{{ atc_method }} AS3 declaration"
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}{{ atc_url }}"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}{{ atc_url }}"
     method: "{{ atc_method }}"
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
     return_content: true
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     body_format: json
     body: "{{ atc_declaration_updated | default(omit) }}"
     status_code: 204, 202, 200
@@ -26,12 +26,12 @@
 
 - name: "{{ atc_method }} DO declaration"
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}{{ atc_url }}"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}{{ atc_url }}"
     method: "{{ atc_method }}"
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
     return_content: true
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     body_format: json
     body: "{{ atc_declaration_updated }}"
     status_code: 202
@@ -44,12 +44,12 @@
 
 - name: "{{ atc_method }} TS declaration"
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}{{ atc_url }}"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}{{ atc_url }}"
     method: "{{ atc_method }}"
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
     return_content: true
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     body_format: json
     body: "{{ atc_declaration_updated }}"
     status_code: 204, 202, 200
@@ -63,12 +63,12 @@
 
 - name: "GET {{ atc_service }} declaration"
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}{{ atc_url }}"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}{{ atc_url }}"
     method: "{{ atc_method }}"
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
     return_content: true
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     status_code: 204, 202, 200
   register: atc_GET_status
   when:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,5 +1,13 @@
 ---
 
+- name: Debug default_provider
+  debug:
+    var: default_provider
+
+- name: Debug provider
+  debug:
+    var: provider
+
 - name: Setup provider and varables
   set_fact:
     provider: "{{ default_provider | combine(provider) }}"
@@ -9,6 +17,14 @@
     atc_tenant: "{{ as3_tenant|default(omit) }}"
     atc_show: "{{ as3_show|default(omit) }}"
     atc_show_hash: "{{ as3_showhash|default(false) }}"
+
+- name: Debug default_provider
+  debug:
+    var: default_provider
+
+- name: Debug provider
+  debug:
+    var: provider
 
 - name: Get declaration from file
   set_fact:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,17 +1,5 @@
 ---
 
-- name: Debug default_provider
-  debug:
-    var: default_provider
-
-- name: Debug provider
-  debug:
-    var: provider
-
-- name: Debug provider combined
-  debug:
-    msg: "{{ default_provider | combine(provider) }}"
-
 - name: Setup provider and varables
   set_fact:
     role_provider: "{{ default_provider | combine(provider) }}"
@@ -21,14 +9,6 @@
     atc_tenant: "{{ as3_tenant|default(omit) }}"
     atc_show: "{{ as3_show|default(omit) }}"
     atc_show_hash: "{{ as3_showhash|default(false) }}"
-
-- name: Debug role_provider
-  debug:
-    var: role_provider
-
-- name: Debug provider
-  debug:
-    var: provider
 
 - name: Get declaration from file
   set_fact:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,8 +1,12 @@
 ---
 
-- name: Setup provider and varables
+- name: Setup role_provider
   set_fact:
     role_provider: "{{ default_provider | combine(provider) }}"
+  no_log: true
+
+- name: Setup varables
+  set_fact:
     atc_declaration: "{{ atc_declaration|default(omit) }}"
     atc_declaration_url: "{{ atc_declaration_url|default(omit) }}"
     atc_declaration_file: "{{ atc_declaration_file|default(omit) }}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -14,7 +14,7 @@
 
 - name: Setup provider and varables
   set_fact:
-    provider: "{{ default_provider | combine(provider) }}"
+    role_provider: "{{ default_provider | combine(provider) }}"
     atc_declaration: "{{ atc_declaration|default(omit) }}"
     atc_declaration_url: "{{ atc_declaration_url|default(omit) }}"
     atc_declaration_file: "{{ atc_declaration_file|default(omit) }}"
@@ -22,9 +22,9 @@
     atc_show: "{{ as3_show|default(omit) }}"
     atc_show_hash: "{{ as3_showhash|default(false) }}"
 
-- name: Debug default_provider
+- name: Debug role_provider
   debug:
-    var: default_provider
+    var: role_provider
 
 - name: Debug provider
   debug:
@@ -77,9 +77,9 @@
 
 - name: Verify "{{ atc_service }}" service is available, and collect service info
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}{{ atc_check_url }}"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}{{ atc_check_url }}"
     timeout: "{{ atc_timeout }}"
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
   register: atc_response
@@ -111,9 +111,9 @@
 
 - name: Check if BIG-IQ (ignore if failed)
   uri:
-    url: "https://{{ provider.server }}:{{ provider.server_port }}/info/system"
+    url: "https://{{ role_provider.server }}:{{ role_provider.server_port }}/info/system"
     timeout: "{{ atc_timeout }}"
-    validate_certs: "{{ provider.validate_certs }}"
+    validate_certs: "{{ role_provider.validate_certs }}"
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
   register: check_bigiq

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -83,6 +83,7 @@
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
   register: atc_response
+  delegate_to: localhost
   until:
     - atc_response is success
     - atc_response.json is defined
@@ -100,6 +101,7 @@
     atc_json_data: "{{ atc_declaration }}"
     atc_version: "{{ atc_response.json }}"
   register: result
+  delegate_to: localhost
   when: check_teem and atc_declaration is defined
 
 - name: Update the atc_declaration
@@ -117,6 +119,7 @@
     headers:
       X-F5-Auth-Token: "{{ f5_auth_token }}"
   register: check_bigiq
+  delegate_to: localhost
   ignore_errors: yes
 
 # BIG-IP task check

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -2,7 +2,7 @@
 
 - name: Setup provider and varables
   set_fact:
-    provider: "{{ provider }}"
+    provider: "{{ default_provider | combine(provider) }}"
     atc_declaration: "{{ atc_declaration|default(omit) }}"
     atc_declaration_url: "{{ atc_declaration_url|default(omit) }}"
     atc_declaration_file: "{{ atc_declaration_file|default(omit) }}"
@@ -24,6 +24,7 @@
     body_format: json
   when: atc_declaration_url is defined
   register: result
+  delegate_to: localhost
   retries: 10
   delay: 5
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -8,6 +8,10 @@
   debug:
     var: provider
 
+- name: Debug provider combined
+  debug:
+    msg: "{{ default_provider | combine(provider) }}"
+
 - name: Setup provider and varables
   set_fact:
     provider: "{{ default_provider | combine(provider) }}"


### PR DESCRIPTION
Due to variable order of precedence, a `set_fact` used within a role cannot overwrite the provider included in a playbook as a role parameter. To work around this I set a `default_provider` in `defaults/main.yml`, created a `role_provider` dictionary in `tasks/main.yml` using the `combine` filter (to combine the defaults with the role parameters set in the playbook), and updated all of the references from `provider.xxx` to `role_provider.xxx`. I'm open to other ideas/methods.

Also split off provider setup and set `no_log: true` to prevent accidental password leakage via `-vv` etc. Note, this does not necessarily prevent debug from exposing the password.

This pull includes the additions of `delegate_to: localhost` referenced in my other Pull Request:

https://github.com/f5devcentral/ansible-role-f5_atc_deploy_declaration/pull/36