### PR TITLE
Install molecule-docker explicitly for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 
 install:
   # Install test dependencies.
-  - pip install molecule docker yamllint flake8 ansible-lint
+  - pip install molecule docker yamllint flake8 ansible-lint molecule-docker
 
 before_script:
   # Use actual Ansible Galaxy role name for the project directory.


### PR DESCRIPTION
See #38 (Travis CI build fails because molecule-docker now has to be installed explicitly)

I haven't tested a Travis CI pipeline with this, but I did run into this issue with molecule and molecule-docker in my own lab as I've been building it out and testing locally.