### PR TITLE
set_fact error f5devcentral.atc_deploy : Update the atc_declaration

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -84,6 +84,7 @@
 - name: Update the atc_declaration
   set_fact:
     atc_declaration_updated: "{{ result.result | default(omit) }}"
+  when: result.result is defined
 
 - name: include declare.yaml
   include_tasks: declare.yaml


### PR DESCRIPTION
During playbook execution (for GET AS3 declaration), I get an error

TASK [f5devcentral.atc_deploy : Update the atc_declaration] ***********************************************************************************************************
fatal: [lb123.example.com]: FAILED! => {"changed": false, "msg": "No key/value pairs provided, at least one is required for this action to succeed"}

The problem started around version ansible [core 2.11.1]

And seems to be related to this change 
https://github.com/ansible/ansible/issues/74851