### PR TITLE
fixing issue#33

### DIFF
--- a/tasks/atc_task_check_bigip.yaml
+++ b/tasks/atc_task_check_bigip.yaml
@@ -14,9 +14,8 @@
   retries: "{{ atc_retries }}"
   delay: "{{ atc_delay }}"
   changed_when: atc_AS3_status.json.results | map(attribute='message') | list | first != 'no change'
-  failed_when:
-    - atc_AS3_status.json.results | map(attribute='message') | list | first != 'success'
-    - atc_AS3_status.json.results | map(attribute='message') | list | first != 'no change'
+  failed_when: ('success' not in (atc_AS3_status.json.results | map(attribute='message') | list) and 'no change' not in (atc_AS3_status.json.results | map(attribute='message') | list) ) or
+    ('declaration failed' in (atc_AS3_status.json.results | map(attribute='message') | list))
   delegate_to: localhost
   when:
     - atc_service == "AS3"


### PR DESCRIPTION
Fixed issue #33  by adding additional failed_when logic check:
- added logic to check when the AS3 response contains the string declaration failed. 
- removed first filter so multiple JSON response elements will be evaluated.
 
The original failed_when logic is still in place. 